### PR TITLE
Add S-1 chatbot scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Data and model artifacts
+data/
+model/
+
+# Python cache files
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-# fintech-analysis
+# Fintech Analysis
+
+This repository demonstrates how to download the Chime S-1 filing and use it to fine-tune a Llama model for a chatbot. Due to the network restrictions in this environment, the provided scripts are designed to be executed in an environment with internet access.
+
+## Setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Create a `requirements.txt` with the following packages (or install them manually):
+
+```
+requests
+beautifulsoup4
+transformers
+datasets
+```
+
+## Download the Chime S-1 Filing
+
+```bash
+python scripts/download_chime_s1.py
+python scripts/preprocess_s1.py
+```
+
+These commands fetch the filing from the SEC and convert it to plain text under `data/chime_s1.txt`.
+
+## Train the Llama Chatbot
+
+Before running the training script, ensure you have accepted the license for the `meta-llama/Llama-2-7b-hf` model on HuggingFace and that you have sufficient compute resources.
+
+```bash
+python scripts/train_llama_chatbot.py
+```
+
+The resulting model will be saved in the `model/` directory.
+
+## Deploy to HuggingFace
+
+After training, you can upload the model using the `huggingface-cli`:
+
+```bash
+huggingface-cli login  # enter your token
+huggingface-cli repo create chime-s1-chatbot
+huggingface-cli upload model/* --repo chime-s1-chatbot
+```
+
+This will create a repository under your HuggingFace account with the trained chatbot.
+
+## Notes
+
+The scripts were developed without internet access in this coding environment, so they have not been executed here. Run them in your local environment with internet connectivity to download the data and train the model.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+requests
+beautifulsoup4
+transformers
+datasets

--- a/scripts/download_chime_s1.py
+++ b/scripts/download_chime_s1.py
@@ -1,0 +1,20 @@
+import os
+import requests
+
+URL = "https://www.sec.gov/Archives/edgar/data/1795586/000162828025025059/chimefinancialinc-sx1wq1da.htm"
+OUTPUT_PATH = os.path.join("data", "chime_s1.html")
+
+
+def download(url: str, output_path: str) -> None:
+    """Download the given URL and save it to the output path."""
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    headers = {"User-Agent": "Mozilla/5.0"}
+    response = requests.get(url, headers=headers)
+    response.raise_for_status()
+    with open(output_path, "wb") as f:
+        f.write(response.content)
+    print(f"Saved {url} to {output_path}")
+
+
+if __name__ == "__main__":
+    download(URL, OUTPUT_PATH)

--- a/scripts/preprocess_s1.py
+++ b/scripts/preprocess_s1.py
@@ -1,0 +1,32 @@
+import os
+import re
+from bs4 import BeautifulSoup
+
+INPUT_FILE = os.path.join("data", "chime_s1.html")
+OUTPUT_FILE = os.path.join("data", "chime_s1.txt")
+
+
+def html_to_text(html_file: str) -> str:
+    with open(html_file, "r", encoding="utf-8", errors="ignore") as f:
+        soup = BeautifulSoup(f, "html.parser")
+    text = soup.get_text(separator="\n")
+    return text
+
+
+def clean_text(text: str) -> str:
+    text = re.sub(r"\s+\n", "\n", text)
+    text = re.sub(r"\n{2,}", "\n\n", text)
+    return text.strip()
+
+
+def save_text(text: str, path: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+
+
+if __name__ == "__main__":
+    raw = html_to_text(INPUT_FILE)
+    cleaned = clean_text(raw)
+    save_text(cleaned, OUTPUT_FILE)
+    print(f"Extracted text saved to {OUTPUT_FILE}")

--- a/scripts/train_llama_chatbot.py
+++ b/scripts/train_llama_chatbot.py
@@ -1,0 +1,52 @@
+"""Fine-tune a Llama model on the Chime S-1 filing."""
+
+import os
+from transformers import (
+    AutoTokenizer,
+    AutoModelForCausalLM,
+    Trainer,
+    TrainingArguments,
+    DataCollatorForLanguageModeling,
+)
+from datasets import load_dataset, Dataset
+
+MODEL_NAME = "meta-llama/Llama-2-7b-hf"  # requires acceptance of the license on HuggingFace
+DATA_FILE = os.path.join("data", "chime_s1.txt")
+
+
+def load_local_dataset(file_path: str, tokenizer):
+    """Create a HuggingFace dataset from a local text file."""
+    texts = [open(file_path, "r", encoding="utf-8").read()]
+    dataset = Dataset.from_dict({"text": texts})
+    return dataset.map(lambda e: tokenizer(e["text"]), batched=True)
+
+
+def main():
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+    model = AutoModelForCausalLM.from_pretrained(MODEL_NAME)
+
+    dataset = load_local_dataset(DATA_FILE, tokenizer)
+    data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
+
+    training_args = TrainingArguments(
+        output_dir="model",
+        num_train_epochs=1,
+        per_device_train_batch_size=1,
+        save_steps=100,
+        logging_steps=10,
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=dataset,
+        data_collator=data_collator,
+    )
+
+    trainer.train()
+    trainer.save_model("model")
+    tokenizer.save_pretrained("model")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add scripts to download and preprocess the Chime S‑1 filing
- include training script for Llama chatbot
- document how to run the pipeline and deploy to HuggingFace
- ignore data and model artifacts
- add package requirements file

## Testing
- `python -m py_compile scripts/*.py`