### PR TITLE
Add Gradio UI for S1 chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ requests
 beautifulsoup4
 transformers
 datasets
+gradio
 ```
 
 ## Download the Chime S-1 Filing
@@ -37,6 +38,16 @@ python scripts/train_llama_chatbot.py
 ```
 
 The resulting model will be saved in the `model/` directory.
+
+## Launch the Chatbot UI
+
+After training, start an interactive Gradio demo with:
+
+```bash
+python app.py
+```
+
+This command opens a local web server where you can ask questions about the Chime S‑1 filing.
 
 ## Deploy to HuggingFace
 

--- a/app.py
+++ b/app.py
@@ -1,0 +1,41 @@
+import os
+import gradio as gr
+from transformers import AutoTokenizer, AutoModelForCausalLM, pipeline
+
+MODEL_PATH = os.getenv("MODEL_PATH", "model")
+
+
+def load_model(path: str):
+    """Load the fine-tuned model from the given path."""
+    tokenizer = AutoTokenizer.from_pretrained(path)
+    model = AutoModelForCausalLM.from_pretrained(path)
+    return pipeline("text-generation", model=model, tokenizer=tokenizer)
+
+
+chatbot = load_model(MODEL_PATH)
+
+
+def respond(message: str, history: list[tuple[str, str]]):
+    """Generate a response for the user's message."""
+    output = chatbot(message, max_new_tokens=200)
+    text = output[0]["generated_text"]
+    if text.startswith(message):
+        text = text[len(message) :]
+    return text.strip()
+
+
+CSS = """
+body {background-color: #f5f7fa;}
+#component-0 {max-width: 800px; margin: auto;}
+"""
+
+with gr.Blocks(css=CSS, title="Chime S-1 Chatbot") as demo:
+    gr.Markdown(
+        """# Chime S‑1 Chatbot
+Ask questions about Chime's S‑1 filing. This interface lets you interact with a Llama model fine‑tuned on the official document.
+"""
+    )
+    gr.ChatInterface(respond)
+
+if __name__ == "__main__":
+    demo.launch()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 beautifulsoup4
 transformers
 datasets
+gradio


### PR DESCRIPTION
## Summary
- add gradio dependency
- provide a slick web/mobile UI for the Chime S-1 model
- document how to launch the chat interface

## Testing
- `pytest -q` *(fails: command not found)*